### PR TITLE
Add teeracle 

### DIFF
--- a/4-development/4.4-sdk/4.4.3-teeracle-oracle-framework.md
+++ b/4-development/4.4-sdk/4.4.3-teeracle-oracle-framework.md
@@ -10,10 +10,10 @@ The exchange rate values are from two different sources, https://www.coingecko.c
 
 ### **How to use the SDK**
 1. Experiment with the template, running the [teeracle demo](../4.6-demos/4.6.3-demo-demo.md)​
-2. Fork the worker repository `https://github.com/integritee-network/worker.git` from the SDK release branch (TODO)
+2. Fork the worker repository `https://github.com/integritee-network/worker.git` from the SDK release branch (TODO release)
 3. Build the worker in [teeracle mode](4.4.3-teeracle-oracle-framework.md#build-teeracle-mode)
 4. Customize [ your own exchange rate oracle](4.4.3-teeracle-oracle-framework.md#customize-exchange-rate)
-5. Deploy on the [Integritee parachain](4.4.7-integritee-parachain-integration.md) or your own testnet (TODO: where?)
+5. Deploy on the [Integritee parachain](4.4.7-integritee-parachain-integration.md) or your own testnet
 6. Add the trusted sources to the [Teeracle whitelist](4.4.3-teeracle-oracle-framework.md#add-to-whitelist)
 7. Try the tutorial [How to build a USD-DOT Oracle from the Template on your own testnet](4.4.3-teeracle-oracle-framework.md#usd-dot-oracle)
 
@@ -36,16 +36,17 @@ An example of a docker build command (as currently used for GitHub CI):
 
 * The core part of the exchange oracle-specific code is in the [ita-exchange-oracle package](https://github.com/integritee-network/worker/tree/master/app-libs/exchange-oracle)
 
-* The oracle is launched at the [start](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/service/src/main.rs#L478) of the service.
+* The teeracle is launched at the [start](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/service/src/main.rs#L478) of the service.
 
-* The exchange rate value is get within the [enclave](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/enclave-runtime/src/teeracle/mod.rs#L119)
+* The exchange rate value is get and updated within the [enclave](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/enclave-runtime/src/teeracle/mod.rs#L86)
 
 #### **Scheduling**
 To change the update rate interval, you can change the default [setting value](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/core-primitives/settings/src/lib.rs#L116) or use a CLI argument: <code><strong>./integritee-service run --teeracle-interval 5s15m2h1d</strong></code>
 
 #### **Trading pair**<a href="#customize-trading-pair" id="customize-tarding-pair"></a>
-The trading pair consists of a crypto- and a fiat currency symbol. Ex: {"TEER", "USD"}. It is set at the start of the oracle service : [teeracle-service](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/service/src/teeracle/mod.rs#L57). To convert the currency symbols into the unique identifiers according to the source API standards, we use a map:  [Coinmarket Cap](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/app-libs/exchange-oracle/src/coin_market_cap.rs#L48) and [CoinGecko](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/app-libs/exchange-oracle/src/coin_gecko.rs#L50). 
+The trading pair consists of a crypto- and a fiat currency symbol. Ex: {"TEER", "USD"}. It is set at the start of the oracle service : [teeracle-service](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/service/src/teeracle/mod.rs#L57).   
 
+To convert the currency symbols into the unique identifiers according to the source API standards, we use a map:  [Coinmarket Cap](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/app-libs/exchange-oracle/src/coin_market_cap.rs#L48) and [CoinGecko](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/app-libs/exchange-oracle/src/coin_gecko.rs#L50). 
 If your currency is not already listed in our mapping already, you will need to add it. It can be looked up in:
 * https://coinmarketcap.com/api/documentation/v1/#section/Standards-and-Conventions
 * https://www.coingecko.com/en/api/documentation
@@ -75,16 +76,19 @@ Define a new type for your oracle in [lib.rs](https://github.com/integritee-netw
 2. Get the exchange rate and create an extrinsic from within the [enclave](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/enclave-runtime/src/teeracle/mod.rs#L119)  
 In [update_market_data_internal](https://github.com/integritee-network/worker/blob/b52be1d355f04e62be5f61d2d9fd2a0ac2fa38a1/enclave-runtime/src/teeracle/mod.rs#L86) add your new oracle.
 
+To remove an existing exchange rate oracle source, you need to:   
+remove the oracle from [update_market_data_internal](https://github.com/integritee-network/worker/blob/b52be1d355f04e62be5f61d2d9fd2a0ac2fa38a1/enclave-runtime/src/teeracle/mod.rs#L86)
+
 ### **Add trusted source to whitelist**<a href="#add-to-whitelist" id="add-to-whitelist"></a>
 The [teeracle pallet](https://github.com/integritee-network/pallets/tree/master/teeracle/src) maintains a whitelist of trusted exchange rate oracles. A trusted source can be added to the whitelist by Sudo or over the [Democracy](2.5.4-democracy.md)
 
 Call : `teeracle, addToWhitelist ( dataSource , 0x mrenclave_hex)`
 
-When the teeracle service is started, the mrenclave hex is written to the logs.
-The dataSource is the base URL of the source:  https://pro-api.coinmarketcap.com/ or https://api.coingecko.com/. Warning: no spaces and / at the end.
+The dataSource is the base URL of the source:  https://pro-api.coinmarketcap.com/ or https://api.coingecko.com/. Warning: no spaces and / at the end.   
+The mrenclave hex is written to the logs, when the teeracle service starts.
 
 ### **How to build a USD-DOT Oracle from the Template on your own testnet**<a href="#usd-dot-oracle" id="usd-dot-oracle">
-1. Fork the worker repository `https://github.com/integritee-network/worker.git` from the SDK release branch (TODO)
+1. Fork the worker repository `https://github.com/integritee-network/worker.git` from the SDK release branch (TODO release)
 3. Customize the [trading pair](4.4.3-teeracle-oracle-framework.md#customize-tarding-pair):
    * Replace "USD" with "DOT" in [file](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/service/src/teeracle/mod.rs#L57)
    * The DOT currency is listed in the:  [Coinmarket Cap](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/app-libs/exchange-oracle/src/coin_market_cap.rs#L48) and [CoinGecko](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/app-libs/exchange-oracle/src/coin_gecko.rs#L50) maps.
@@ -96,7 +100,7 @@ The dataSource is the base URL of the source:  https://pro-api.coinmarketcap.com
    COINMARKETCAP_KEY="xxxxxxxxxxxx"
    export COINMARKETCAP_KEY` 
    ```
-7. Run the teeracle service in dev mode with a smaller update rate interval 24s\
+7. Run the teeracle service in dev mode with a smaller update rate interval 24s
    ```
    cd bin
    ./integritee-service --clean-reset run --node-url <yournodeip> --node-port <port> --dev  --teeracle-interval 24s

--- a/4-development/4.4-sdk/4.4.3-teeracle-oracle-framework.md
+++ b/4-development/4.4-sdk/4.4.3-teeracle-oracle-framework.md
@@ -1,3 +1,106 @@
 # 4.4.3 TEEracle -  Oracle Framework
+The TEEracle SDK facilitates submission of trustworthy oracle data into the Integritee parachain. It retrieves website or API data and serves source-authenticated data to the parachain.
 
-Coming soon, stay tuned !
+### **Generic TEEracle**
+Coming soon !
+
+### **Exchange rate oracle**
+We already have a running TEEracle connected to the Integritee parachain that supplies the TEER-USD exchange rate. This exchange rate will be used to offer stable USD fees.  
+The exchange rate values are from two different sources, https://www.coingecko.com/ and https://coinmarketcap.com/api/, and updated once per day.
+
+### **How to use the SDK**
+1. Experiment with the template, running the [teeracle demo](../4.6-demos/4.6.3-demo-demo.md)​
+2. Fork the worker repository `https://github.com/integritee-network/worker.git` from the SDK release branch (TODO)
+3. Build the worker in [teeracle mode](4.4.3-teeracle-oracle-framework.md#build-teeracle-mode)
+4. Customize [ your own exchange rate oracle](4.4.3-teeracle-oracle-framework.md#customize-exchange-rate)
+5. Deploy on the [Integritee parachain](4.4.7-integritee-parachain-integration.md) or your own testnet (TODO: where?)
+6. Add the trusted sources to the [Teeracle whitelist](4.4.3-teeracle-oracle-framework.md#add-to-whitelist)
+7. Try the tutorial [How to build a USD-DOT Oracle from the Template on your own testnet](4.4.3-teeracle-oracle-framework.md#usd-dot-oracle)
+
+### **Building the worker in teeracle mode** <a href="#build-teeracle-mode" id="build-teeracle-mode"></a>
+
+In order to build the worker in teeracle mode, the corresponding cargo feature `teeracle` needs to be set. In the Makefiles, the environment variable `WORKER_MODE` is used to set the cargo features.
+
+In case you build with `make` directly, do so with:
+
+`1WORKER_MODE=teeracle make`
+
+In case you use docker with our `build.Dockerfile`, use `--build-arg WORKER_MODE_ARG=teeracle` to set the corresponding docker `ARG`.
+
+An example of a docker build command (as currently used for GitHub CI):
+
+<pre data-line-numbers><code><strong>docker build -t integritee-worker --target deployed-worker --build-arg WORKER_MODE_ARG=teeracle -f build.Dockerfile .</strong></code></pre>
+
+
+### **Customizing an Exchange Rate Oracle** <a href="#customize-exchange-rate" id="customize-exchange-rate"></a>
+
+* The core part of the exchange oracle-specific code is in the [ita-exchange-oracle package](https://github.com/integritee-network/worker/tree/master/app-libs/exchange-oracle)
+
+* The oracle is launched at the [start](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/service/src/main.rs#L478) of the service.
+
+* The exchange rate value is get within the [enclave](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/enclave-runtime/src/teeracle/mod.rs#L119)
+
+#### **Scheduling**
+To change the update rate interval, you can change the default [setting value](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/core-primitives/settings/src/lib.rs#L116) or use a CLI argument: <code><strong>./integritee-service run --teeracle-interval 5s15m2h1d</strong></code>
+
+#### **Trading pair**<a href="#customize-trading-pair" id="customize-tarding-pair"></a>
+The trading pair consists of a crypto- and a fiat currency symbol. Ex: {"TEER", "USD"}. It is set at the start of the oracle service : [teeracle-service](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/service/src/teeracle/mod.rs#L57). To convert the currency symbols into the unique identifiers according to the source API standards, we use a map:  [Coinmarket Cap](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/app-libs/exchange-oracle/src/coin_market_cap.rs#L48) and [CoinGecko](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/app-libs/exchange-oracle/src/coin_gecko.rs#L50). 
+
+If your currency is not already listed in our mapping already, you will need to add it. It can be looked up in:
+* https://coinmarketcap.com/api/documentation/v1/#section/Standards-and-Conventions
+* https://www.coingecko.com/en/api/documentation
+
+See [How to build a USD-DOT Oracle from the Template on your own testnet](4.4.3-teeracle-oracle-framework.md#usd-dot-oracle) as example.
+
+#### **API Keys**
+Our Teeracle reads the Api-Key from an environment variable.
+
+Coinmarket Cap needs an API-Key, which has to be set in the environment variable [COINMARKETCAP_KEY](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/app-libs/exchange-oracle/src/coin_market_cap.rs#L51).
+
+#### **Exchange Rate Oracle Source**
+To add a new exchange rate oracle, you need to :
+1. Create an oracle with a new source in [ita-exchange-oracle package](https://github.com/integritee-network/worker/tree/master/app-libs/exchange-oracle)
+* **New source**   
+We query the exchange rate value via the REST API of the desired source. We use a TLS RestAPI client and explicitly check that the source's TLS-Root-Certificates are correct. This gives us non-repudiation, i.e, it is guaranteed that the result is indeed from the advertised source.   
+The code for our two sources can be found in [Coinmarket Cap](https://github.com/integritee-network/worker/blob/master/app-libs/exchange-oracle/src/coin_market_cap.rs) and [CoinGecko](https://github.com/integritee-network/worker/blob/master/app-libs/exchange-oracle/src/coin_gecko.rs).   
+The new _ExchangeRateSource_ must :
+   * implement the [OraclSource trait](https://github.com/integritee-network/worker/blob/b52be1d355f04e62be5f61d2d9fd2a0ac2fa38a1/app-libs/exchange-oracle/src/exchange_rate_oracle.rs#L36).
+   * provide a valid root certificate and the HTTP request to the right endpoint.
+   * define the mapping between the currency symbols and the ID used to identify the exchange rate endpoint.
+   * implement the parsing of the JSON response data to get the exchange rate value
+     
+* **New oracle**  
+Define a new type for your oracle in [lib.rs](https://github.com/integritee-network/worker/blob/master/app-libs/exchange-oracle/src/lib.rs) and add a create function.
+
+2. Get the exchange rate and create an extrinsic from within the [enclave](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/enclave-runtime/src/teeracle/mod.rs#L119)  
+In [update_market_data_internal](https://github.com/integritee-network/worker/blob/b52be1d355f04e62be5f61d2d9fd2a0ac2fa38a1/enclave-runtime/src/teeracle/mod.rs#L86) add your new oracle.
+
+### **Add trusted source to whitelist**<a href="#add-to-whitelist" id="add-to-whitelist"></a>
+The [teeracle pallet](https://github.com/integritee-network/pallets/tree/master/teeracle/src) maintains a whitelist of trusted exchange rate oracles. A trusted source can be added to the whitelist by Sudo or over the [Democracy](2.5.4-democracy.md)
+
+Call : `teeracle, addToWhitelist ( dataSource , 0x mrenclave_hex)`
+
+When the teeracle service is started, the mrenclave hex is written to the logs.
+The dataSource is the base URL of the source:  https://pro-api.coinmarketcap.com/ or https://api.coingecko.com/. Warning: no spaces and / at the end.
+
+### **How to build a USD-DOT Oracle from the Template on your own testnet**<a href="#usd-dot-oracle" id="usd-dot-oracle">
+1. Fork the worker repository `https://github.com/integritee-network/worker.git` from the SDK release branch (TODO)
+3. Customize the [trading pair](4.4.3-teeracle-oracle-framework.md#customize-tarding-pair):
+   * Replace "USD" with "DOT" in [file](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/service/src/teeracle/mod.rs#L57)
+   * The DOT currency is listed in the:  [Coinmarket Cap](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/app-libs/exchange-oracle/src/coin_market_cap.rs#L48) and [CoinGecko](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/app-libs/exchange-oracle/src/coin_gecko.rs#L50) maps.
+    
+4. Build the worker in [teeracle mode](4.4.3-teeracle-oracle-framework.md#build-teeracle-mode)
+5. Run an Integritee solo node in dev mode. The node [runtime](https://github.com/integritee-network/integritee-node/blob/268a0d22dc598ae82515e57406c8044ddda5219f/runtime/src/lib.rs#L646) has the [teeracle pallet](https://github.com/integritee-network/pallets/tree/master/teeracle/src)
+6. Coinmarket Cap needs an API-Key. Get it from `https://coinmarketcap.com/api/documentation/v1/#section/Introduction` and set it as environment variable:
+   ```
+   COINMARKETCAP_KEY="xxxxxxxxxxxx"
+   export COINMARKETCAP_KEY` 
+   ```
+7. Run the teeracle service in dev mode with a smaller update rate interval 24s\
+   ```
+   cd bin
+   ./integritee-service --clean-reset run --node-url <yournodeip> --node-port <port> --dev  --teeracle-interval 24s
+   ```
+8. Add Coingecko and Coinmarket_CAP to [whitelist with a SUDO](4.4.3-teeracle-oracle-framework.md#add-to-whitelist).
+9. Check the events in https://polkadot.js.org : `teeracle.ExchangeRateUpdated`.\
+   You should get every 24s an event for https://api.coingecko.com/ and an event for https://pro-api.coinmarketcap.com/ with the TEER/DOT exchange rate value

--- a/4-development/4.4-sdk/4.4.3-teeracle-oracle-framework.md
+++ b/4-development/4.4-sdk/4.4.3-teeracle-oracle-framework.md
@@ -19,18 +19,19 @@ The exchange rate values are from two different sources, https://www.coingecko.c
 
 ### **Building the worker in teeracle mode** <a href="#build-teeracle-mode" id="build-teeracle-mode"></a>
 
-In order to build the worker in teeracle mode, the corresponding cargo feature `teeracle` needs to be set. In the Makefiles, the environment variable `WORKER_MODE` is used to set the cargo features.
+In order to build the worker in teeracle mode, the corresponding cargo feature `teeracle` needs to be set. In the Makefiles, the environment variable `WORKER_MODE` is used to set the cargo features for the worker mode.
 
 In case you build with `make` directly, do so with:
 
-`1WORKER_MODE=teeracle make`
+`WORKER_MODE=teeracle make`
 
 In case you use docker with our `build.Dockerfile`, use `--build-arg WORKER_MODE_ARG=teeracle` to set the corresponding docker `ARG`.
 
 An example of a docker build command (as currently used for GitHub CI):
 
-<pre data-line-numbers><code><strong>docker build -t integritee-worker --target deployed-worker --build-arg WORKER_MODE_ARG=teeracle -f build.Dockerfile .</strong></code></pre>
-
+```
+docker build -t integritee-worker --target deployed-worker --build-arg WORKER_MODE_ARG=teeracle -f build.Dockerfile 
+```
 
 ### **Customizing an Exchange Rate Oracle** <a href="#customize-exchange-rate" id="customize-exchange-rate"></a>
 
@@ -87,7 +88,7 @@ Call : `teeracle, addToWhitelist ( dataSource , 0x mrenclave_hex)`
 The dataSource is the base URL of the source:  https://pro-api.coinmarketcap.com/ or https://api.coingecko.com/. Warning: no spaces and / at the end.   
 The mrenclave hex is written to the logs, when the teeracle service starts.
 
-### **How to build a USD-DOT Oracle from the Template on your own testnet**<a href="#usd-dot-oracle" id="usd-dot-oracle">
+### **How to build a USD-DOT Oracle from the Template on your own testnet**<a href="#usd-dot-oracle" id="usd-dot-oracle"></a>
 1. Fork the worker repository `https://github.com/integritee-network/worker.git` from the SDK release branch (TODO release)
 3. Customize the [trading pair](4.4.3-teeracle-oracle-framework.md#customize-tarding-pair):
    * Replace "USD" with "DOT" in [file](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/service/src/teeracle/mod.rs#L57)
@@ -107,4 +108,4 @@ The mrenclave hex is written to the logs, when the teeracle service starts.
    ```
 8. Add Coingecko and Coinmarket_CAP to [whitelist with a SUDO](4.4.3-teeracle-oracle-framework.md#add-to-whitelist).
 9. Check the events in https://polkadot.js.org : `teeracle.ExchangeRateUpdated`.\
-   You should get every 24s an event for https://api.coingecko.com/ and an event for https://pro-api.coinmarketcap.com/ with the TEER/DOT exchange rate value
+   You should get every 24s an event for https://api.coingecko.com/ and an event for https://pro-api.coinmarketcap.com/ with the USD/DOT exchange rate value

--- a/4-development/4.4-sdk/4.4.3-teeracle-oracle-framework.md
+++ b/4-development/4.4-sdk/4.4.3-teeracle-oracle-framework.md
@@ -91,7 +91,7 @@ The mrenclave hex is written to the logs, when the teeracle service starts.
 ### **How to build a USD-DOT Oracle from the Template on your own testnet**<a href="#usd-dot-oracle" id="usd-dot-oracle"></a>
 1. Fork the worker repository `https://github.com/integritee-network/worker.git` from the SDK release branch (TODO release)
 3. Customize the [trading pair](4.4.3-teeracle-oracle-framework.md#customize-tarding-pair):
-   * Replace "USD" with "DOT" in [file](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/service/src/teeracle/mod.rs#L57)
+   * Replace "TEER" with "DOT" in [file](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/service/src/teeracle/mod.rs#L57)
    * The DOT currency is listed in the:  [Coinmarket Cap](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/app-libs/exchange-oracle/src/coin_market_cap.rs#L48) and [CoinGecko](https://github.com/integritee-network/worker/blob/2471cc52cf0377323886a43b0e7c2e9181265a67/app-libs/exchange-oracle/src/coin_gecko.rs#L50) maps.
     
 4. Build the worker in [teeracle mode](4.4.3-teeracle-oracle-framework.md#build-teeracle-mode)

--- a/4-development/4.6-demos/4.6.3-teeracle-demo.md
+++ b/4-development/4.6-demos/4.6.3-teeracle-demo.md
@@ -1,3 +1,111 @@
 # 4.6.3 TEEracle demo
 
-Coming soon, stay tuned !
+The TEEracle demo can be a good starting point in understanding how the TEEracle service provides trustworthy oracle to an Integritee Node. 
+
+The demo sets up an Integritee Node (layer 1 chain) and runs 1 worker that provides the TEER-USD exchange rate. The exchange rate will be updated on the Integritee Node only when it comes from reliable code:
+- the enclave is registered in the Integritee Node -> The oracle run on a SGX device
+- the enclave is in the teeracle whitelist -> The running code is reliable. Sudo or the technical committee have checked it.
+
+The CLI client (called by a script) is used to count the ExchangeRateUpdated events and add the enclave in the whitelist.
+
+The sequence is as follows:
+
+1. Count the exchange rate updates when the enclave is not in the whitelist
+2. Add the enclave in the whitelist for the source https://api.coingecko.com/
+3. Count the exchange rate updates with one trusted oracle
+4. Add the enclave in the whitelist for a second source, https://pro-api.coinmarketcap.com/
+5. Count the exchange rate updates with two trusted oracles
+
+The test passed  if   
+* there are no exchange rate updates before the enclave is added to the whitelist 
+* the number of exchange rate updates with one trusted oracle > Minimum expected number of events with a single oracle
+8.the number of exchange rate updates with two trusted oracles > Minimum expected number of events with two oracles 
+
+
+### Run the TEEracle demo
+In order to run the demo, clone the worker repository:
+
+```
+git clone https://github.com/integritee-network/worker.git
+```
+
+Change directory to
+
+```
+cd docker
+```
+
+Build all necessary images in the docker-compose setup, with (takes upwards of 10 minutes, depending on your hardware):
+
+```
+COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -f docker-compose.yml -f demo-teeracle.yml build --build-arg WORKER_MODE_ARG=teeracle
+```
+
+Run the demo in the docker-compose setup
+
+```
+docker-compose -f docker-compose.yml -f demo-teeracle.yml up --exit-code-from demo-teeracle
+```
+
+You will see log output from the worker and the demo service. First worker will startup and initialize. The demo service waits for worker to be fully up before running. This whole process can take a couple of minutes and will automatically shut down once the demo script ran through.
+
+Output like
+
+```
+integritee-teeracle-demo  | 2022/09/01 08:57:58 Waiting for http://integritee-teeracle-worker:4645/is_initialized: unexpected HTTP status code: 404.
+```
+
+is to be expected, it results from the demo service `integritee-teeracle-demo` polling and waiting until `teeracle-worker:4645` is initialized.
+
+The demo run will show :
+
+```
+integritee-teeracle-demo  | Minimum expected number of events with a single oracle: 3
+integritee-teeracle-demo  | Minimum expected number of events with two oracles: 6
+...
+integritee-teeracle-demo  | Got 0 exchange rate updates when no trusted oracle source is in the whitelist
+...
+integritee-teeracle-demo  | MRENCLAVE in whitelist for https://api.coingecko.com/
+...
+integritee-teeracle-demo  | Got 4 exchange rate updates from the trusted oracle source in 21 second(s)
+...
+integritee-teeracle-demo  | MRENCLAVE in whitelist for https://pro-api.coinmarketcap.com/
+...
+integritee-teeracle-demo  | Got 7 exchange rate updates from 2 trusted oracle sources in 21 second(s)
+
+```
+
+The number of events can be different. A successful demo run will show 
+
+```
+integritee-teeracle-demo  | 
+integritee-teeracle-demo  | Results :
+integritee-teeracle-demo  | test passed
+integritee-teeracle-demo exited with code 0
+```
+
+at the end of the log output, before the docker containers are stopped.
+
+The test can fail for various reasons:
+
+```
+integritee-teeracle-demo  | The test ran through but we received ExchangeRateUpdated events before the enclave was added to the whitelist. Was the enclave previously whitelisted? Perhaps by another teeracle?
+```
+or 
+
+```
+integritee-teeracle-demo  | test failed: Not enough events received for single oracle source: $EVENTS_COUNT. Should be greater than $MIN_EXPECTED_NUM_OF_EVENTS
+```
+or
+
+```
+integritee-teeracle-demo  |test failed: Not enough events received for 2 oracle sources: $EVENTS_COUNT_2. Should be greater than $MIN_EXPECTED_NUM_OF_EVENTS_2
+```
+
+Use
+
+```
+docker-compose -f docker-compose.yml -f demo-teeracle.yml down
+```
+
+to clean up all the container context (including logs).


### PR DESCRIPTION
- add teeracle demo
- add teeracle SDK
I built the doc in the same way as the other SDK doc: sidechain and off-chain-worker and have added some of the content of the existing version  https://integritee-network.gitbook.io/integritee-wiki/for-developers/teeracle

I aslo added a small tutorial according https://github.com/integritee-network/teeracle/issues/29