### PR TITLE
4.9: minor fixes

### DIFF
--- a/4-development/4.9-dev-environment.md
+++ b/4-development/4.9-dev-environment.md
@@ -19,8 +19,11 @@ The launch scripts assume that those two repositories reside in the same directo
 Steps to get a running setup:
 
 1. Mount the current directory containing the integritee-worker and integritee node into the Docker container and start a bash session inside: 
-```
+```shell
 docker run -it --mount "type=bind,src=$(pwd),dst=/opt/shared" --workdir /opt/shared integritee/integritee-dev:0.1.10 /bin/bash
+
+# If you want to expose the default ports of the services to the host, you can supply some `-p` args:
+docker run -it --mount "type=bind,src=$(pwd),dst=/opt/shared" --workdir /opt/shared -p 9944:9944 -p 2000:2000 -p 3443:3443 integritee/integritee-dev:0.1.10 /bin/bash
 ```
 2. Now you have access to the shell in the Docker container. So you can start the builds.
 ```shell

--- a/4-development/4.9-dev-environment.md
+++ b/4-development/4.9-dev-environment.md
@@ -20,7 +20,7 @@ Steps to get a running setup:
 
 1. Mount the current directory containing the integritee-worker and integritee node into the Docker container and start a bash session inside: 
 ```
-docker run -it --mount "type=bind,src=$(pwd),dst=/opt/shared" --workdir /opt/shared  -p integritee/integritee-dev:0.1.10 /bin/bash
+docker run -it --mount "type=bind,src=$(pwd),dst=/opt/shared" --workdir /opt/shared integritee/integritee-dev:0.1.10 /bin/bash
 ```
 2. Now you have access to the shell in the Docker container. So you can start the builds.
 ```shell

--- a/4-development/4.9-dev-environment.md
+++ b/4-development/4.9-dev-environment.md
@@ -34,7 +34,7 @@ cargo build release --features "skip-extrinsic-filtering skip-ias-check"
 cd ../
 
 # Build the worker: in this example we compile it in the offchain worker mode.
-cd integritee-worker
+cd worker
 
 # Build the offchain-worker in software mode if you don't have the SGX hardware set up.
 # How to enable hardware mode in Docker can be found here in chapter 5.2.3.3.
@@ -49,7 +49,7 @@ SGX_MODE=SW WORKER_MODE=offchain-worker make
 docker exec -it <container-id> bash
  
 # Have a look at the logs with the handy tmux scripts (the logs are only populated if the launch.py was used).
-cd integritee-worker/local-setup
+cd worker/local-setup
 ./tmux_logger.sh
  
 # The demo scripts can be executed in yet another terminal session where you enter the same running Docker container.
@@ -57,7 +57,7 @@ cd integritee-worker/local-setup
 docker exec -it <container-id> bash
 
 # This script also shows what kind of commands you can execute with the CLI.
-cd integritee-worker/cli
+cd worker/cli
 ./demo_shielding_unshielding.sh
 
 # Check available commands of the CLI.


### PR DESCRIPTION
Changes:
* Fix: remove dangling `-p` of the docker run command
* Add docker run example that exposes ports to the host
* rename `integritee-worker` to `worker` as this is the repo's name.