### PR TITLE
fix: typos in documentation files

### DIFF
--- a/4-development/4.4-sdk/4.4.1-sidechain-sdk.md
+++ b/4-development/4.4-sdk/4.4.1-sidechain-sdk.md
@@ -8,7 +8,7 @@
 4. Write and integrate your own [#business-logic-stf](4.4.1-sidechain-sdk.md#business-logic-stf "mention"), e.g. in a substrate pallet.
 5. Deploy on the [Integritee parachain](4.4.7-integritee-parachain-integration.md) or your own testnet.
 
-### **Building the worker in sidechain validateer mode** <a href="#build-sidechain-mode" id="build-sidechain-mode"></a>
+### **Building the worker in sidechain validator mode** <a href="#build-sidechain-mode" id="build-sidechain-mode"></a>
 
 In order to build the worker in sidechain mode, the corresponding cargo feature `sidechain` needs to be set. In the Makefiles, the environment variable `WORKER_MODE` is used to set the cargo features for the worker mode.
 

--- a/4-development/4.6-demos/4.6.3-teeracle-demo.md
+++ b/4-development/4.6-demos/4.6.3-teeracle-demo.md
@@ -25,7 +25,7 @@ The test passed if
 
 ### Run the TEEracle demo
 
-The demo is executed in docker to set up the the Integritee node and the teeracle, but it essentially runs the [demo\_teeracle\_whitelist.sh](https://github.com/integritee-network/worker/blob/master/cli/demo\_teeracle\_whitelist.sh) script for teeracle's registration process.
+The demo is executed in docker to set up the Integritee node and the teeracle, but it essentially runs the [demo\_teeracle\_whitelist.sh](https://github.com/integritee-network/worker/blob/master/cli/demo\_teeracle\_whitelist.sh) script for teeracle's registration process.
 
 In order to run the demo, clone the worker repository:
 

--- a/4-development/4.7-performance-benchmarking.md
+++ b/4-development/4.7-performance-benchmarking.md
@@ -15,9 +15,9 @@ for `sdk-v0.10.0-polkadot-v0.9.27,` running on Intel(R) Xeon(R) E-2176G CPU @ 3.
 * With a **300ms blocktime** we can process **up to 1900 tps** and at least 38 tps at a state size of 4000 accounts
 * With a 6s blocktime we can process up to 900 tps and at least 10 tps at a state size of 100’000 accounts (around 20MB)
 * typical throughput is 500 tps
-* **At least 250 clients** can connect to one validateer concurrently and send at least on tx per block
+* **At least 250 clients** can connect to one validator concurrently and send at least on tx per block
 
-With identified state handling improvements, we should be able to improve state size degratation by 6x:
+With identified state handling improvements, we should be able to improve state size degradation by 6x:
 
 * With a 300ms blocktime 38 tps at a state size of 24'000 accounts
 
@@ -25,7 +25,7 @@ With identified state handling improvements, we should be able to improve state 
 
 * down to 300ms block time
 * 500 tps typical per sidechain, degrading above 5’000 accounts state size
-* 250 wss concurrent client connections per validateer
+* 250 wss concurrent client connections per validator
 * overall sharded throughput of integritee network currently extrapolates to **50k tps** (improvements of polkadot protocol and our sidechain finality can potentially push this towards an estimated **1-4M tps**)
 
 ### ****

--- a/6-misc/6.3-community-info-and-links.md
+++ b/6-misc/6.3-community-info-and-links.md
@@ -1,6 +1,6 @@
 # 6.3 Community Info & Links
 
-### **1. Our Most imortant Link:**&#x20;
+### **1. Our Most important Link:**&#x20;
 
 &#x20;:deciduous\_tree: **LinkTree** [https://linktr.ee/Integritee](https://linktr.ee/Integritee)
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "validateer" to "validator".
Corrected "set up the the Integritee" to "set up the Integritee".
Corrected "degratation" to "degradation".
Corrected "imortant" to "important".

Please review the changes and let me know if any additional changes are needed.